### PR TITLE
Allow data to be `null` (in addition to `undefined`)

### DIFF
--- a/lib/controller.js
+++ b/lib/controller.js
@@ -185,7 +185,7 @@ class Controller extends DataService {
 
   setResData(data, scope, statusCode) {
     if (!statusCode) {
-      if (typeof data != 'undefined') {
+      if (data) {
         statusCode = (scope.newContent ? HTTP_STATUSES.CREATED.code : HTTP_STATUSES.OK.code);
       } else {
         statusCode = HTTP_STATUSES.NO_CONTENT.code;


### PR DESCRIPTION
 For example, user can type the following custom action:

```
doMe(scope) {
    let req = scope.req;
    let context = scope.context;

    return Bb
      .try(() => {
        scope.res.statusCode = HTTP_STATUSES.NO_CONTENT.code;

        return null;
      })
      .catch((err) => {
        this.setResError(err, scope);
      });
  }
```

`data  == null` here and status sets to 204 as not undefined.